### PR TITLE
fix missing space in boost message

### DIFF
--- a/src/ui/Message/index.tsx
+++ b/src/ui/Message/index.tsx
@@ -231,7 +231,7 @@ class Message extends React.PureComponent<Props, any> {
                   return (
                     <React.Fragment key={message.id}>
                       <Secondary.Boost>
-                        {member}{Locale.translate('frontend.messages.boost')}
+                        {member} {Locale.translate('frontend.messages.boost')}
                       </Secondary.Boost>
                       <Timestamp time={message.createdAt} />
                     </React.Fragment>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
before: missing space
![img](https://advaith.is-in-hyper.space/1ddcc662ff.png)

after: space
![ing](https://advaith.is-in-hyper.space/863202d359.png)