### PR TITLE
Fix sidebar background toggle

### DIFF
--- a/src/ui/Header/Hamburger/index.tsx
+++ b/src/ui/Header/Hamburger/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Burger, Ham } from './elements'
 
 interface Props {
-  onClick?: Function
+  onClick?: React.MouseEventHandler;
   open?: boolean
 }
 

--- a/src/ui/Header/index.tsx
+++ b/src/ui/Header/index.tsx
@@ -13,7 +13,13 @@ const Header = observer(({ children }) => (
       <ServerInfo />
     </SingleChannel>
     <Inner>
-      <Hamburger onClick={store.sidebar.toggle} open={store.sidebar.isOpen} />
+      <Hamburger
+        onClick={e => {
+          e.stopPropagation();
+          store.sidebar.toggle();
+        }}
+        open={store.sidebar.isOpen}
+      />
       {children}
     </Inner>
   </Root>

--- a/src/ui/Wrapper/index.tsx
+++ b/src/ui/Wrapper/index.tsx
@@ -6,7 +6,7 @@ import { store } from '@models'
 const Wrapper = observer(({ children }) => (
   <Root
     onClick={() => {
-      if (store.sidebar.isOpen && window.innerWidth < 120) {
+      if (store.sidebar.isOpen && window.innerWidth < 520) {
         store.sidebar.toggle()
       }
     }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When the window is narrow (<520px), opening the sidebar causes the main window to be
obscured by an overlay. Clicking on this overlay should close the sidebar. The logic seems
to be there already, but gated at an incorrect window width.
