### PR TITLE
Clarify hits-per-month badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [WidgetBot](https://widgetbot.io) ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg) [![Crate](https://data.jsdelivr.com/v1/package/npm/@widgetbot/crate/badge?style=rounded)](https://www.jsdelivr.com/package/npm/@widgetbot/crate) [![](https://data.jsdelivr.com/v1/package/npm/@widgetbot/html-embed/badge?style=rounded)](https://www.jsdelivr.com/package/npm/@widgetbot/html-embed)
+# [WidgetBot](https://widgetbot.io) ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg) [![Crate](https://img.shields.io/jsdelivr/npm/hm/@widgetbot/crate?color=ff6135&label=jsdelivr%20hits%20%28Crate%29)](https://www.jsdelivr.com/package/npm/@widgetbot/crate) [![](https://img.shields.io/jsdelivr/npm/hm/@widgetbot/html-embed?color=ff6135&label=jsdelivr%20hits%20%28html-embed%29)](https://www.jsdelivr.com/package/npm/@widgetbot/html-embed)
 
 > WidgetBot is a pixel-perfect open-source Discord chat widget for your website.
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changes the Badges from the JSDelivr badges to Shields.io ones using their `/jsdelivr/npm/` support.

The reason for the change is the fact, that the JSDelivr badge itself doesn't seem to allow customization of the Label text. This - especially in the case here - makes it confusing to know what NPM package now gets 2M hits a month and which gets 6M hits a month (Those numbers also seem to be *very generously* rounded by JSDelivr, so perhaps also more accurate numbers now?).

With shields, we now have a way to set a little note on the label to show the difference. This should help clarify things a bit.