### PR TITLE
fix images and videos overflowing

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-icons": "^3.0.5",
     "react-loadable": "^5.5.0",
     "react-notification-system": "^0.2.17",
+    "react-resize-aware": "3.1.1",
     "react-router-dom": "^6.3.0",
     "react-spinkit": "^3.0.0",
     "react-string-replace": "^1.0.0",

--- a/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
@@ -4,6 +4,7 @@ import ExpandableImage from "@ui/shared/ExpandableImage";
 import {ImageAttachmentBase} from "@ui/Messages/Content/Attachment/elements";
 import { useContext } from "react";
 import { ScrollerWidthContext } from "@ui/Messages";
+import { FullWidthSpacing } from "..";
 
 interface ImageAttachmentProps {
   attachment: Message_attachments;
@@ -11,7 +12,7 @@ interface ImageAttachmentProps {
 
 function ImageAttachment(props: ImageAttachmentProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const { width, height } = useSize(props.attachment.width, props.attachment.height, undefined, scrollerWidth ? scrollerWidth - 134 : undefined);
+  const { width, height } = useSize(props.attachment.width, props.attachment.height, undefined, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
 
   return (
     <ExpandableImage src={props.attachment.url} width={width} height={height} className={ImageAttachmentBase} />

--- a/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
@@ -2,13 +2,16 @@ import {Message_attachments} from "@generated";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import ExpandableImage from "@ui/shared/ExpandableImage";
 import {ImageAttachmentBase} from "@ui/Messages/Content/Attachment/elements";
+import { useContext } from "react";
+import { ScrollerWidthContext } from "@ui/Messages";
 
 interface ImageAttachmentProps {
   attachment: Message_attachments;
 }
 
 function ImageAttachment(props: ImageAttachmentProps) {
-  const { width, height } = useSize(props.attachment.width, props.attachment.height);
+  const scrollerWidth = useContext(ScrollerWidthContext)
+  const { width, height } = useSize(props.attachment.width, props.attachment.height, undefined, scrollerWidth ? scrollerWidth - 134 : undefined);
 
   return (
     <ExpandableImage src={props.attachment.url} width={width} height={height} className={ImageAttachmentBase} />

--- a/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
@@ -12,7 +12,8 @@ interface ImageAttachmentProps {
 
 function ImageAttachment(props: ImageAttachmentProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const { width, height } = useSize(props.attachment.width, props.attachment.height, undefined, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
+  const maxWidth = scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined;
+  const { width, height } = useSize(props.attachment.width, props.attachment.height, undefined, maxWidth);
 
   return (
     <ExpandableImage src={props.attachment.url} width={width} height={height} className={ImageAttachmentBase} />

--- a/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/ImageAttachment.tsx
@@ -3,7 +3,7 @@ import useSize from "@ui/Messages/Content/Attachment/useSize";
 import ExpandableImage from "@ui/shared/ExpandableImage";
 import {ImageAttachmentBase} from "@ui/Messages/Content/Attachment/elements";
 import { useContext } from "react";
-import { ScrollerWidthContext } from "@ui/Messages";
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import { FullWidthSpacing } from "..";
 
 interface ImageAttachmentProps {

--- a/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
@@ -8,7 +8,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import fileSize from "filesize";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import { useContext } from "react";
-import { ScrollerWidthContext } from "@ui/Messages";
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import { FullWidthSpacing } from "..";
 
 interface VideoAttachmentProps {

--- a/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
@@ -66,7 +66,8 @@ function VideoAttachment(props: VideoAttachmentProps) {
   const {width: extractedWidth, height: extractedHeight} = "width" in props.attachmentOrEmbed ? props.attachmentOrEmbed : props.attachmentOrEmbed.video;
 
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const { width, height } = useSize(extractedWidth, extractedHeight, isFullscreen, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
+  const maxWidth = scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined;
+  const { width, height } = useSize(extractedWidth, extractedHeight, isFullscreen, maxWidth);
 
   const fullScreenChange = () => {
     setIsFullscreen(document.fullscreenElement !== null);

--- a/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
@@ -9,6 +9,7 @@ import fileSize from "filesize";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import { useContext } from "react";
 import { ScrollerWidthContext } from "@ui/Messages";
+import { FullWidthSpacing } from "..";
 
 interface VideoAttachmentProps {
   attachmentOrEmbed: Message_attachments | Message_embeds | {
@@ -65,7 +66,7 @@ function VideoAttachment(props: VideoAttachmentProps) {
   const {width: extractedWidth, height: extractedHeight} = "width" in props.attachmentOrEmbed ? props.attachmentOrEmbed : props.attachmentOrEmbed.video;
 
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const { width, height } = useSize(extractedWidth, extractedHeight, isFullscreen, scrollerWidth ? scrollerWidth - 134 : undefined);
+  const { width, height } = useSize(extractedWidth, extractedHeight, isFullscreen, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
 
   const fullScreenChange = () => {
     setIsFullscreen(document.fullscreenElement !== null);

--- a/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
+++ b/src/ui/Messages/Content/Attachment/VideoAttachment.tsx
@@ -7,6 +7,8 @@ import {
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import fileSize from "filesize";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
+import { useContext } from "react";
+import { ScrollerWidthContext } from "@ui/Messages";
 
 interface VideoAttachmentProps {
   attachmentOrEmbed: Message_attachments | Message_embeds | {
@@ -62,7 +64,8 @@ function VideoAttachment(props: VideoAttachmentProps) {
 
   const {width: extractedWidth, height: extractedHeight} = "width" in props.attachmentOrEmbed ? props.attachmentOrEmbed : props.attachmentOrEmbed.video;
 
-  const { width, height } = useSize(extractedWidth, extractedHeight, isFullscreen);
+  const scrollerWidth = useContext(ScrollerWidthContext)
+  const { width, height } = useSize(extractedWidth, extractedHeight, isFullscreen, scrollerWidth ? scrollerWidth - 134 : undefined);
 
   const fullScreenChange = () => {
     setIsFullscreen(document.fullscreenElement !== null);

--- a/src/ui/Messages/Content/Attachment/useSize.ts
+++ b/src/ui/Messages/Content/Attachment/useSize.ts
@@ -1,7 +1,7 @@
 const MaxAttachmentWidth = 400;
 const MaxAttachmentHeight = 300;
 
-function useSize(width: number, height: number, disabled?: boolean) {
+function useSize(width: number, height: number, disabled?: boolean, maxWidth?: number) {
   if (disabled) {
     return {
       width: undefined,
@@ -13,7 +13,8 @@ function useSize(width: number, height: number, disabled?: boolean) {
     Math.floor(
       Math.min(height, MaxAttachmentHeight) / height * width
     ),
-    MaxAttachmentWidth
+    MaxAttachmentWidth,
+    maxWidth || MaxAttachmentWidth
   );
   const resultingHeight = Math.min(
     height,

--- a/src/ui/Messages/Content/Attachment/useSize.ts
+++ b/src/ui/Messages/Content/Attachment/useSize.ts
@@ -14,7 +14,7 @@ function useSize(width: number, height: number, disabled?: boolean, maxWidth?: n
       Math.min(height, MaxAttachmentHeight) / height * width
     ),
     MaxAttachmentWidth,
-    maxWidth || MaxAttachmentWidth
+    maxWidth ?? MaxAttachmentWidth
   );
   const resultingHeight = Math.min(
     height,

--- a/src/ui/Messages/Content/Embed/EmbedVideo.tsx
+++ b/src/ui/Messages/Content/Embed/EmbedVideo.tsx
@@ -1,9 +1,10 @@
 import {Embed_thumbnail, Embed_video} from "@generated";
 import {VideoIframe, VideoThumbnail} from "@ui/Messages/Content/Embed/elements";
 import VideoAttachment from "@ui/Messages/Content/Attachment/VideoAttachment";
-import {ReactNode, useState} from "react";
+import {ReactNode, useContext, useState} from "react";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import DiscordImageFailure from "@images/discordAssets/discord-image-failure.svg";
+import { ScrollerWidthContext } from "@ui/Messages";
 
 interface ThumbnailWrapperProps {
   thumbnail?: Embed_thumbnail["url"];
@@ -16,8 +17,6 @@ function ThumbnailWrapper({ thumbnail, width, height, children }: ThumbnailWrapp
   const [hideThumbnail, setHideThumbnail] = useState(false);
   const [error, setError] = useState(false);
 
-  const { width: adjustedWidth, height: adjustedHeight } = useSize(width, height);
-
   if (!thumbnail || hideThumbnail)
     return <>{children}</>;
 
@@ -26,10 +25,7 @@ function ThumbnailWrapper({ thumbnail, width, height, children }: ThumbnailWrapp
       onClick={() => setHideThumbnail(true)}
       src={error ? DiscordImageFailure : thumbnail}
       onError={() => setError(true)}
-      style={{
-        width: adjustedWidth,
-        height: adjustedHeight,
-      }}
+      style={{ width, height }}
     />
   );
 }
@@ -41,13 +37,16 @@ interface EmbedVideoProps extends Pick<Embed_video, "width" | "height"> {
 }
 
 function EmbedVideo(props: EmbedVideoProps) {
+  const scrollerWidth = useContext(ScrollerWidthContext)
+  const { width, height } = useSize(props.width, props.height, undefined, scrollerWidth ? scrollerWidth - 166 : undefined);
+
   if (props.proxyUrl !== null)
     return (
-      <ThumbnailWrapper thumbnail={props.thumbnail} width={props.width} height={props.height}>
+      <ThumbnailWrapper thumbnail={props.thumbnail} width={width} height={height}>
         <VideoAttachment
           attachmentOrEmbed={{
-            width: props.width,
-            height: props.height,
+            width,
+            height,
             url: props.proxyUrl,
           }}
         />
@@ -59,10 +58,10 @@ function EmbedVideo(props: EmbedVideoProps) {
   url.searchParams.set("auto_play", "1");
 
   return (
-    <ThumbnailWrapper thumbnail={props.thumbnail} width={props.width} height={props.height}>
+    <ThumbnailWrapper thumbnail={props.thumbnail} width={width} height={height}>
       <VideoIframe
-        width={400}
-        height={225}
+        width={width}
+        height={height}
         src={url.toString()}
         allowFullScreen={true}
       />

--- a/src/ui/Messages/Content/Embed/EmbedVideo.tsx
+++ b/src/ui/Messages/Content/Embed/EmbedVideo.tsx
@@ -4,7 +4,7 @@ import VideoAttachment from "@ui/Messages/Content/Attachment/VideoAttachment";
 import {ReactNode, useContext, useState} from "react";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import DiscordImageFailure from "@images/discordAssets/discord-image-failure.svg";
-import { ScrollerWidthContext } from "@ui/Messages";
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import { EmbedMediaSpacing } from "..";
 
 interface ThumbnailWrapperProps {

--- a/src/ui/Messages/Content/Embed/EmbedVideo.tsx
+++ b/src/ui/Messages/Content/Embed/EmbedVideo.tsx
@@ -5,6 +5,7 @@ import {ReactNode, useContext, useState} from "react";
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import DiscordImageFailure from "@images/discordAssets/discord-image-failure.svg";
 import { ScrollerWidthContext } from "@ui/Messages";
+import { EmbedMediaSpacing } from "..";
 
 interface ThumbnailWrapperProps {
   thumbnail?: Embed_thumbnail["url"];
@@ -38,7 +39,7 @@ interface EmbedVideoProps extends Pick<Embed_video, "width" | "height"> {
 
 function EmbedVideo(props: EmbedVideoProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const { width, height } = useSize(props.width, props.height, undefined, scrollerWidth ? scrollerWidth - 166 : undefined);
+  const { width, height } = useSize(props.width, props.height, undefined, scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined);
 
   if (props.proxyUrl !== null)
     return (

--- a/src/ui/Messages/Content/Embed/EmbedVideo.tsx
+++ b/src/ui/Messages/Content/Embed/EmbedVideo.tsx
@@ -39,7 +39,8 @@ interface EmbedVideoProps extends Pick<Embed_video, "width" | "height"> {
 
 function EmbedVideo(props: EmbedVideoProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const { width, height } = useSize(props.width, props.height, undefined, scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined);
+  const maxWidth = scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined;
+  const { width, height } = useSize(props.width, props.height, undefined, maxWidth);
 
   if (props.proxyUrl !== null)
     return (

--- a/src/ui/Messages/Content/Embed/GifVEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/GifVEmbed.tsx
@@ -1,13 +1,16 @@
 import useSize from "@ui/Messages/Content/Attachment/useSize";
 import {MediaEmbedBase} from "@ui/Messages/Content/Embed/elements";
 import {Message_embeds} from "@generated";
+import { useContext } from "react";
+import { ScrollerWidthContext } from "@ui/Messages";
 
 export interface GifVEmbedProps {
   embed: Message_embeds;
 }
 
 function GifVEmbed({embed}: GifVEmbedProps) {
-  const size = useSize(embed.video.width, embed.video.height);
+  const scrollerWidth = useContext(ScrollerWidthContext)
+  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - 134 : undefined);
 
   return (
     <video

--- a/src/ui/Messages/Content/Embed/GifVEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/GifVEmbed.tsx
@@ -3,6 +3,7 @@ import {MediaEmbedBase} from "@ui/Messages/Content/Embed/elements";
 import {Message_embeds} from "@generated";
 import { useContext } from "react";
 import { ScrollerWidthContext } from "@ui/Messages";
+import { FullWidthSpacing } from "..";
 
 export interface GifVEmbedProps {
   embed: Message_embeds;
@@ -10,7 +11,7 @@ export interface GifVEmbedProps {
 
 function GifVEmbed({embed}: GifVEmbedProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - 134 : undefined);
+  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
 
   return (
     <video

--- a/src/ui/Messages/Content/Embed/GifVEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/GifVEmbed.tsx
@@ -11,7 +11,8 @@ export interface GifVEmbedProps {
 
 function GifVEmbed({embed}: GifVEmbedProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
+  const maxWidth = scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined;
+  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, maxWidth);
 
   return (
     <video

--- a/src/ui/Messages/Content/Embed/GifVEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/GifVEmbed.tsx
@@ -2,7 +2,7 @@ import useSize from "@ui/Messages/Content/Attachment/useSize";
 import {MediaEmbedBase} from "@ui/Messages/Content/Embed/elements";
 import {Message_embeds} from "@generated";
 import { useContext } from "react";
-import { ScrollerWidthContext } from "@ui/Messages";
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import { FullWidthSpacing } from "..";
 
 export interface GifVEmbedProps {

--- a/src/ui/Messages/Content/Embed/ImageEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/ImageEmbed.tsx
@@ -12,7 +12,8 @@ export interface GifVEmbedProps {
 
 function ImageEmbed({embed}: GifVEmbedProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
+  const maxWidth = scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined;
+  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, maxWidth);
 
   return (
     <ExpandableImage

--- a/src/ui/Messages/Content/Embed/ImageEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/ImageEmbed.tsx
@@ -2,13 +2,16 @@ import useSize from "@ui/Messages/Content/Attachment/useSize";
 import {MediaEmbedBase} from "@ui/Messages/Content/Embed/elements";
 import ExpandableImage from "@ui/shared/ExpandableImage";
 import {Message_embeds} from "@generated";
+import { useContext } from "react";
+import { ScrollerWidthContext } from "@ui/Messages";
 
 export interface GifVEmbedProps {
   embed: Message_embeds;
 }
 
 function ImageEmbed({embed}: GifVEmbedProps) {
-  const size = useSize(embed.thumbnail.width, embed.thumbnail.height);
+  const scrollerWidth = useContext(ScrollerWidthContext)
+  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - 134 : undefined);
 
   return (
     <ExpandableImage

--- a/src/ui/Messages/Content/Embed/ImageEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/ImageEmbed.tsx
@@ -4,6 +4,7 @@ import ExpandableImage from "@ui/shared/ExpandableImage";
 import {Message_embeds} from "@generated";
 import { useContext } from "react";
 import { ScrollerWidthContext } from "@ui/Messages";
+import { FullWidthSpacing } from "..";
 
 export interface GifVEmbedProps {
   embed: Message_embeds;
@@ -11,7 +12,7 @@ export interface GifVEmbedProps {
 
 function ImageEmbed({embed}: GifVEmbedProps) {
   const scrollerWidth = useContext(ScrollerWidthContext)
-  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - 134 : undefined);
+  const size = useSize(embed.thumbnail.width, embed.thumbnail.height, undefined, scrollerWidth ? scrollerWidth - FullWidthSpacing : undefined);
 
   return (
     <ExpandableImage

--- a/src/ui/Messages/Content/Embed/ImageEmbed.tsx
+++ b/src/ui/Messages/Content/Embed/ImageEmbed.tsx
@@ -3,7 +3,7 @@ import {MediaEmbedBase} from "@ui/Messages/Content/Embed/elements";
 import ExpandableImage from "@ui/shared/ExpandableImage";
 import {Message_embeds} from "@generated";
 import { useContext } from "react";
-import { ScrollerWidthContext } from "@ui/Messages";
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import { FullWidthSpacing } from "..";
 
 export interface GifVEmbedProps {

--- a/src/ui/Messages/Content/Embed/index.tsx
+++ b/src/ui/Messages/Content/Embed/index.tsx
@@ -13,7 +13,7 @@ import EmbedVideo from "@ui/Messages/Content/Embed/EmbedVideo";
 import { settingsStore } from "@store";
 import { store } from "@models";
 import { useContext, useEffect, useState } from "react";
-import { ScrollerWidthContext } from "@ui/Messages";
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import { EmbedMediaSpacing } from "..";
 
 export interface EmbedProps {

--- a/src/ui/Messages/Content/Embed/index.tsx
+++ b/src/ui/Messages/Content/Embed/index.tsx
@@ -14,6 +14,7 @@ import { settingsStore } from "@store";
 import { store } from "@models";
 import { useContext, useEffect, useState } from "react";
 import { ScrollerWidthContext } from "@ui/Messages";
+import { EmbedMediaSpacing } from "..";
 
 export interface EmbedProps {
   embed: Message_embeds;
@@ -46,14 +47,14 @@ function Embed({embed, images}: EmbedProps) {
     embed.type,
     embed.image,
     images?.length > 0,
-    scrollerWidth ? scrollerWidth - 166 : undefined
+    scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined
   );
 
   const { width: widthThumbnail, height: heightThumbnail, isLarge: isThumbnailLarge } = useSize(
     embed.type,
     embed.thumbnail,
     undefined,
-    scrollerWidth ? scrollerWidth - 166 : undefined
+    scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined
   );
 
   return (

--- a/src/ui/Messages/Content/Embed/index.tsx
+++ b/src/ui/Messages/Content/Embed/index.tsx
@@ -12,6 +12,8 @@ import useSize from "@ui/Messages/Content/Embed/useSize";
 import EmbedVideo from "@ui/Messages/Content/Embed/EmbedVideo";
 import { settingsStore } from "@store";
 import { store } from "@models";
+import { useContext, useEffect, useState } from "react";
+import { ScrollerWidthContext } from "@ui/Messages";
 
 export interface EmbedProps {
   embed: Message_embeds;
@@ -38,16 +40,20 @@ function Embed({embed, images}: EmbedProps) {
     ? numberToRgb(embed.color)
     : undefined;
 
+  const scrollerWidth = useContext(ScrollerWidthContext)
+
   const { width: widthImage, height: heightImage } = useSize(
     embed.type,
     embed.image,
-    images?.length > 0
+    images?.length > 0,
+    scrollerWidth ? scrollerWidth - 166 : undefined
   );
 
   const { width: widthThumbnail, height: heightThumbnail, isLarge: isThumbnailLarge } = useSize(
     embed.type,
     embed.thumbnail,
-    undefined
+    undefined,
+    scrollerWidth ? scrollerWidth - 166 : undefined
   );
 
   return (

--- a/src/ui/Messages/Content/Embed/index.tsx
+++ b/src/ui/Messages/Content/Embed/index.tsx
@@ -42,19 +42,20 @@ function Embed({embed, images}: EmbedProps) {
     : undefined;
 
   const scrollerWidth = useContext(ScrollerWidthContext)
+  const maxWidth = scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined
 
   const { width: widthImage, height: heightImage } = useSize(
     embed.type,
     embed.image,
     images?.length > 0,
-    scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined
+    maxWidth
   );
 
   const { width: widthThumbnail, height: heightThumbnail, isLarge: isThumbnailLarge } = useSize(
     embed.type,
     embed.thumbnail,
     undefined,
-    scrollerWidth ? scrollerWidth - EmbedMediaSpacing : undefined
+    maxWidth
   );
 
   return (

--- a/src/ui/Messages/Content/Embed/useSize.ts
+++ b/src/ui/Messages/Content/Embed/useSize.ts
@@ -4,7 +4,8 @@ import {Message_embeds_image, Message_embeds_thumbnail} from "@generated";
 function useSize(
   type: string,
   image: Message_embeds_image | Message_embeds_thumbnail,
-  cancel?: boolean
+  cancel?: boolean,
+  maxWidth?: number
 ) {
   const { width, height, isLarge } = useMemo(() => {
     if (cancel)
@@ -14,10 +15,10 @@ function useSize(
       return { width: null, height: null, isLarge: false };
 
     if (image.__typename === "EmbedImage" || /^article|image$/i.test(type)) {
-      const proposedWidth = 400;
+      const proposedWidth = maxWidth ? Math.min(400, maxWidth) : 400;
       const proposedHeight = proposedWidth / image.width * image.height;
 
-      const { width, height } = proposedHeight > proposedWidth
+      const { width, height } = proposedHeight > proposedWidth && maxWidth >= 300
         ? { width: 300 / image.height * image.width, height: 300 }
         : { width: proposedWidth, height: proposedHeight };
 
@@ -33,7 +34,7 @@ function useSize(
       : { imageWidth: 80 * image.width / image.height, imageHeight: 80 };
 
     return { width: imageWidth, height: imageHeight, isLarge: false };
-  }, [type, image, image, cancel]);
+  }, [type, image, image, cancel, maxWidth]);
 
   return { width, height, isLarge };
 }

--- a/src/ui/Messages/Content/Embed/useSize.ts
+++ b/src/ui/Messages/Content/Embed/useSize.ts
@@ -1,6 +1,10 @@
 import {useMemo} from "react";
 import {Message_embeds_image, Message_embeds_thumbnail} from "@generated";
 
+const MaxImageWidth = 400;
+const MaxImageHeight = 300;
+const MaxThumbnailSize = 80;
+
 function useSize(
   type: string,
   image: Message_embeds_image | Message_embeds_thumbnail,
@@ -15,11 +19,11 @@ function useSize(
       return { width: null, height: null, isLarge: false };
 
     if (image.__typename === "EmbedImage" || /^article|image$/i.test(type)) {
-      const proposedWidth = maxWidth ? Math.min(400, maxWidth) : 400;
+      const proposedWidth = maxWidth ? Math.min(MaxImageWidth, maxWidth) : MaxImageWidth;
       const proposedHeight = proposedWidth / image.width * image.height;
 
-      const { width, height } = proposedHeight > proposedWidth && maxWidth >= 300
-        ? { width: 300 / image.height * image.width, height: 300 }
+      const { width, height } = proposedHeight > proposedWidth && maxWidth >= MaxImageHeight
+        ? { width: MaxImageHeight / image.height * image.width, height: MaxImageHeight }
         : { width: proposedWidth, height: proposedHeight };
 
       return {
@@ -30,8 +34,8 @@ function useSize(
     }
 
     const { imageHeight, imageWidth } = image.width > image.height
-      ? { imageWidth: 80, imageHeight: 80 / image.width * image.height }
-      : { imageWidth: 80 * image.width / image.height, imageHeight: 80 };
+      ? { imageWidth: MaxThumbnailSize, imageHeight: MaxThumbnailSize / image.width * image.height }
+      : { imageWidth: MaxThumbnailSize * image.width / image.height, imageHeight: MaxThumbnailSize };
 
     return { width: imageWidth, height: imageHeight, isLarge: false };
   }, [type, image, image, cancel, maxWidth]);

--- a/src/ui/Messages/Content/index.tsx
+++ b/src/ui/Messages/Content/index.tsx
@@ -32,6 +32,9 @@ import ThreadButton from "@ui/Messages/Content/Thread/ThreadButton";
 import Message from "../Message";
 import Embed from "@ui/Messages/Content/Embed";
 
+export const FullWidthSpacing = 134
+export const EmbedMediaSpacing = 166
+
 interface EditedProps {
   editedAt: number;
 }

--- a/src/ui/Messages/index.tsx
+++ b/src/ui/Messages/index.tsx
@@ -24,7 +24,7 @@ function MessageGroup(props: MessageProps) {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        <Message isFirstMessage={true} message={firstMessage} isHovered={isHovered} showButtons={props.showButtons ?? true} thread={props.thread} />
+        <Message isFirstMessage message={firstMessage} isHovered={isHovered} showButtons={props.showButtons ?? true} thread={props.thread} />
         {otherMessages.map(message => (
           <Message key={message.id} message={message} showButtons={props.showButtons ?? true} thread={props.thread} />
         ))}

--- a/src/ui/Messages/index.tsx
+++ b/src/ui/Messages/index.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, createContext, useState} from "react";
+import {CSSProperties, useState} from "react";
 import {Message as MessageData} from "@generated";
 import {MessageGroupBase} from "@ui/Messages/elements";
 import Message from "@ui/Messages/Message";

--- a/src/ui/Messages/index.tsx
+++ b/src/ui/Messages/index.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useState} from "react";
+import {CSSProperties, createContext, useState} from "react";
 import {Message as MessageData} from "@generated";
 import {MessageGroupBase} from "@ui/Messages/elements";
 import Message from "@ui/Messages/Message";
@@ -8,23 +8,28 @@ interface MessageProps {
   style?: CSSProperties;
   showButtons?: boolean;
   thread: boolean;
+  scrollerWidth?: number;
 }
+
+export const ScrollerWidthContext = createContext(null)
 
 function MessageGroup(props: MessageProps) {
   const [firstMessage, ...otherMessages] = props.messages;
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <MessageGroupBase
-      style={props.style}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <Message isFirstMessage={true} message={firstMessage} isHovered={isHovered} showButtons={props.showButtons ?? true} thread={props.thread} />
-      {otherMessages.map(message => (
-        <Message key={message.id} message={message} showButtons={props.showButtons ?? true} thread={props.thread} />
-      ))}
-    </MessageGroupBase>
+    <ScrollerWidthContext.Provider value={props.scrollerWidth}>
+      <MessageGroupBase
+        style={props.style}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <Message isFirstMessage={true} message={firstMessage} isHovered={isHovered} showButtons={props.showButtons ?? true} thread={props.thread} />
+        {otherMessages.map(message => (
+          <Message key={message.id} message={message} showButtons={props.showButtons ?? true} thread={props.thread} />
+        ))}
+      </MessageGroupBase>
+    </ScrollerWidthContext.Provider>
   );
 }
 

--- a/src/ui/Messages/index.tsx
+++ b/src/ui/Messages/index.tsx
@@ -8,28 +8,23 @@ interface MessageProps {
   style?: CSSProperties;
   showButtons?: boolean;
   thread: boolean;
-  scrollerWidth?: number;
 }
-
-export const ScrollerWidthContext = createContext(null)
 
 function MessageGroup(props: MessageProps) {
   const [firstMessage, ...otherMessages] = props.messages;
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <ScrollerWidthContext.Provider value={props.scrollerWidth}>
-      <MessageGroupBase
-        style={props.style}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <Message isFirstMessage message={firstMessage} isHovered={isHovered} showButtons={props.showButtons ?? true} thread={props.thread} />
-        {otherMessages.map(message => (
-          <Message key={message.id} message={message} showButtons={props.showButtons ?? true} thread={props.thread} />
-        ))}
-      </MessageGroupBase>
-    </ScrollerWidthContext.Provider>
+    <MessageGroupBase
+      style={props.style}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Message isFirstMessage message={firstMessage} isHovered={isHovered} showButtons={props.showButtons ?? true} thread={props.thread} />
+      {otherMessages.map(message => (
+        <Message key={message.id} message={message} showButtons={props.showButtons ?? true} thread={props.thread} />
+      ))}
+    </MessageGroupBase>
   );
 }
 

--- a/src/views/Messages/Header/Pins/index.tsx
+++ b/src/views/Messages/Header/Pins/index.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState } from 'react'
 import { PinButton, Display, Title, List, Pin, NoPins } from './elements'
 import noPins from '@images/discordAssets/ef3a1ed683cfcf029971b12a26462072.svg'
 import Tooltip from 'rc-tooltip'
+import { ScrollerWidthContext } from '@ui/Messages';
+import useResizeAware from 'react-resize-aware';
 
 export default observer(() => {
     const [right, setRight] = useState(0)
@@ -35,6 +37,8 @@ export default observer(() => {
         }
     })
 
+    const [resizeListener, sizes] = useResizeAware();
+
     const pins = generalStore.pins
 
     return <>
@@ -45,20 +49,23 @@ export default observer(() => {
             <PinButton innerRef={ref => (button = ref)} onClick={() => generalStore.togglePins()} open={generalStore.pinsOpen} className="pin-button" x="0" y="0" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M22 12L12.101 2.10101L10.686 3.51401L12.101 4.92901L7.15096 9.87801V9.88001L5.73596 8.46501L4.32196 9.88001L8.56496 14.122L2.90796 19.778L4.32196 21.192L9.97896 15.536L14.222 19.778L15.636 18.364L14.222 16.95L19.171 12H19.172L20.586 13.414L22 12Z"></path></PinButton>
         </Tooltip>
         {generalStore.pinsOpen && <Display right={right} innerRef={ref => (display = ref)} className="pin-display">
+            {resizeListener}
             <Title className="pin-title">Pinned Messages</Title>
-            <List className="pin-list">
-                {pins
-                    ? pins.length
-                        ? pins.map(pin => <Pin key={pin.id} className="pin">
-                            <Message isFirstMessage={true} message={pin} showButtons={false} />
-                        </Pin>)
-                        : <NoPins className="no-pins">
-                            <img src={noPins} alt="no pins" />
-                            <span>This channel doesn't have any <br /> pinned messages... yet.</span>
-                          </NoPins>
-                    : <div style={{ height: '300px' }}><Loading /></div>
-                }
-            </List>
+            <ScrollerWidthContext.Provider value={sizes.width}>
+                <List className="pin-list">
+                    {pins
+                        ? pins.length
+                            ? pins.map(pin => <Pin key={pin.id} className="pin">
+                                <Message isFirstMessage={true} message={pin} showButtons={false} />
+                            </Pin>)
+                            : <NoPins className="no-pins">
+                                <img src={noPins} alt="no pins" />
+                                <span>This channel doesn't have any <br /> pinned messages... yet.</span>
+                            </NoPins>
+                        : <div style={{ height: '300px' }}><Loading /></div>
+                    }
+                </List>
+            </ScrollerWidthContext.Provider>
         </Display>}
     </>
 })

--- a/src/views/Messages/Header/Pins/index.tsx
+++ b/src/views/Messages/Header/Pins/index.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 import { PinButton, Display, Title, List, Pin, NoPins } from './elements'
 import noPins from '@images/discordAssets/ef3a1ed683cfcf029971b12a26462072.svg'
 import Tooltip from 'rc-tooltip'
-import { ScrollerWidthContext } from '@ui/Messages';
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 import useResizeAware from 'react-resize-aware';
 
 export default observer(() => {

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -21,7 +21,7 @@ type MessagesProps = {
   thread?: boolean;
 };
 
-export const ScrollerWidthContext = createContext(null)
+export const ScrollerWidthContext = createContext<number | null>(null)
 
 export const Messages = observer(({ guild, channel, thread = false }: MessagesProps) => {
   const { messages, error, ready, stale, fetchMore } = useMessages(channel, guild, thread ? generalStore.activeThread.id : null);

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -139,6 +139,7 @@ export const Messages = observer(({ guild, channel, thread = false }: MessagesPr
                                     messages={groupedMessages[index]}
                                     style={style}
                                     thread={thread}
+                                    scrollerWidth={width}
                                   />
                                 </CellMeasurer>
                             ) : null

--- a/src/views/Messages/Messages2ElectricBoogaloo.tsx
+++ b/src/views/Messages/Messages2ElectricBoogaloo.tsx
@@ -10,6 +10,7 @@ import {MessagesWrapper, ScrollerSpacer} from "@views/Messages/elements";
 import { Virtuoso } from "react-virtuoso";
 import MessageGroup from "@ui/Messages";
 import useResizeAware from 'react-resize-aware';
+import { ScrollerWidthContext } from "@views/Messages/Messages";
 
 const maxMessagesToLoad = 30;
 
@@ -63,28 +64,30 @@ function Messages2ElectricBoogaloo({ guild, channel, thread = false }: MessagesP
   return (
     <MessagesWrapper stale={stale}>
       {resizeListener}
-      <Virtuoso
-        data={groupedMessages}
-        firstItemIndex={firstItemIndex}
-        overscan={100}
-        startReached={loadMoreMessages}
-        initialTopMostItemIndex={maxMessagesToLoad - 1}
-        alignToBottom={true}
-        followOutput={(isAtBottom: boolean) => {
-          if (isAtBottom) {
-            return 'auto' // can be 'auto' or false to avoid scrolling
-          }
+      <ScrollerWidthContext.Provider value={sizes.width}>
+        <Virtuoso
+          data={groupedMessages}
+          firstItemIndex={firstItemIndex}
+          overscan={100}
+          startReached={loadMoreMessages}
+          initialTopMostItemIndex={maxMessagesToLoad - 1}
+          alignToBottom={true}
+          followOutput={(isAtBottom: boolean) => {
+            if (isAtBottom) {
+              return 'auto' // can be 'auto' or false to avoid scrolling
+            }
 
-          return false;
-        }}
-        atBottomThreshold={2}
-        components={{
-          Footer: () => <ScrollerSpacer />,
-        }}
-        itemContent={(index, messageGroup) => (
-          <MessageGroup messages={messageGroup} key={messageGroup[0].id} thread={thread} scrollerWidth={sizes.width} />
-        )}
-      />
+            return false;
+          }}
+          atBottomThreshold={2}
+          components={{
+            Footer: () => <ScrollerSpacer />,
+          }}
+          itemContent={(index, messageGroup) => (
+            <MessageGroup messages={messageGroup} key={messageGroup[0].id} thread={thread} />
+          )}
+        />
+      </ScrollerWidthContext.Provider>
     </MessagesWrapper>
   );
 }

--- a/src/views/Messages/Messages2ElectricBoogaloo.tsx
+++ b/src/views/Messages/Messages2ElectricBoogaloo.tsx
@@ -9,6 +9,7 @@ import {useCallback, useMemo, useState} from "react";
 import {MessagesWrapper, ScrollerSpacer} from "@views/Messages/elements";
 import { Virtuoso } from "react-virtuoso";
 import MessageGroup from "@ui/Messages";
+import useResizeAware from 'react-resize-aware';
 
 const maxMessagesToLoad = 30;
 
@@ -36,6 +37,8 @@ function Messages2ElectricBoogaloo({ guild, channel, thread = false }: MessagesP
     setFirstItemIndex(firstItemIndex - groupMessages(data.channel.messageBunch.messages).length);
   }, [fetchMore, firstItemIndex, groupedMessages]);
 
+  const [resizeListener, sizes] = useResizeAware();
+
   if (error) {
     addNotification({
       level: 'warning',
@@ -59,6 +62,7 @@ function Messages2ElectricBoogaloo({ guild, channel, thread = false }: MessagesP
 
   return (
     <MessagesWrapper stale={stale}>
+      {resizeListener}
       <Virtuoso
         data={groupedMessages}
         firstItemIndex={firstItemIndex}
@@ -78,7 +82,7 @@ function Messages2ElectricBoogaloo({ guild, channel, thread = false }: MessagesP
           Footer: () => <ScrollerSpacer />,
         }}
         itemContent={(index, messageGroup) => (
-          <MessageGroup messages={messageGroup} key={messageGroup[0].id} thread={thread} />
+          <MessageGroup messages={messageGroup} key={messageGroup[0].id} thread={thread} scrollerWidth={sizes.width} />
         )}
       />
     </MessagesWrapper>

--- a/src/views/Messages/elements.ts
+++ b/src/views/Messages/elements.ts
@@ -25,6 +25,7 @@ export const MessageList = styled(AutoSizer)``
 
 export const MessagesWrapper = styled.div<MessagesWrapperProps>`
   flex-grow: 1;
+  position: relative;
 
   ${MessageList} {
     transition: opacity 0.2s ease;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11253,6 +11253,11 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
+react-resize-aware@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.1.1.tgz#a428fd53f34dec3a52b68c923a6ebe51a192c63c"
+  integrity sha512-M8IyVLBN8D6tEUss+bxQlWte3ZYtNEGhg7rBxtCVG8yEBjUlZwUo5EFLq6tnvTZXcgAbCLjsQn+NCoTJKumRYg==
+
 react-router-dom@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"


### PR DESCRIPTION
puts the scroller width in a context and passes it to useSize to prevent images and videos going out of the embed
