### PR TITLE
update single-channel and thread headers

### DIFF
--- a/src/ui/Header/Hamburger/elements.ts
+++ b/src/ui/Header/Hamburger/elements.ts
@@ -32,7 +32,7 @@ export const Ham = styled('button')<Props>`
   background: none;
   flex-shrink: 0;
   color: ${({ theme }) => theme.colors.accent};
-  display: ${({ theme }) => theme.singleChannel ? 'none' : 'inline-block'};
+  display: ${({ theme, thread }) => theme.singleChannel && !thread ? 'none' : 'inline-block'};
   margin-left: 20px;
   margin-right: 10px;
   position: relative;

--- a/src/ui/Header/elements.ts
+++ b/src/ui/Header/elements.ts
@@ -19,6 +19,14 @@ export const Root = styled('header')`
 
 export const SingleChannel = styled('div')`
   ${({theme}) => theme.singleChannel ? null : 'display: none'}
+
+  @media (max-width: 520px) {
+    width: 47px;
+
+    &:hover {
+      width: auto;
+    }
+  }
 `
 
 export const Inner = styled('div')`

--- a/src/ui/Header/elements.ts
+++ b/src/ui/Header/elements.ts
@@ -18,7 +18,7 @@ export const Root = styled('header')`
 `
 
 export const SingleChannel = styled('div')`
-  ${({theme}) => theme.singleChannel ? null : 'display: none'}
+  ${({theme}) => theme.singleChannel ? null : 'display: none;'}
 
   @media (max-width: 520px) {
     width: 47px;

--- a/src/ui/Header/index.tsx
+++ b/src/ui/Header/index.tsx
@@ -12,9 +12,11 @@ interface Props {
 
 const Header = observer(({ children, thread = false }: Props) => (
   <Root className="header">
-    <SingleChannel>
-      <ServerInfo />
-    </SingleChannel>
+    {(!thread || generalStore.threadFullscreen) && (
+      <SingleChannel>
+        <ServerInfo />
+      </SingleChannel>
+    )}
     <Inner>
       <Hamburger
         onClick={e => {

--- a/src/views/Messages/Header/Header.tsx
+++ b/src/views/Messages/Header/Header.tsx
@@ -85,10 +85,11 @@ export const Header = observer(({ channel, thread }: HeaderProps) => {
             {thread || ['VoiceChannel', 'ForumChannel'].includes(cData.__typename) || <ThreadBrowser count={cData.threads?.length} />}
             {/* {(!thread || generalStore.threadFullscreen) && <Pins />} Thread pins are disabled */}
             {thread || ['VoiceChannel', 'ForumChannel'].includes(cData.__typename) || <Pins />}
-            <SingleChannelAuthWrapper>
-                <SingleChannelAuth />
-            </SingleChannelAuthWrapper>
-            {invite ? <Tooltip placement="bottom" overlay={Locale.translate('opendiscord.tooltip')}>
+            {(!thread || generalStore.threadFullscreen) && <>
+                <SingleChannelAuthWrapper>
+                    <SingleChannelAuth />
+                </SingleChannelAuthWrapper>
+                {invite ? <Tooltip placement="bottom" overlay={Locale.translate('opendiscord.tooltip')}>
                     <Join
                         className="join"
                         href={invite}
@@ -99,6 +100,7 @@ export const Header = observer(({ channel, thread }: HeaderProps) => {
                         {Locale.translate('opendiscord')}
                     </Join>
                 </Tooltip> : null}
+            </>}
 
           {thread && !generalStore.threadFullscreen && (
             // This is rancid, idk how to do this properly honestly


### PR DESCRIPTION
* collapses single-channel server info on small widths until hovered
* fixes thread headers when in single channel mode