### PR TITLE
fix closing default thread

### DIFF
--- a/src/stores/general.ts
+++ b/src/stores/general.ts
@@ -19,6 +19,7 @@ export class GeneralStore {
   @observable menuOpen: boolean = false;
   @observable activeThread?: Thread;
   @observable threadFullscreen: boolean = false;
+  @observable openedDefaultThread: boolean = false;
   @observable file?: File;
   @observable emojis = new EmojiStore(...defaultEmojis);
   @observable pins?: Message[];
@@ -64,6 +65,10 @@ export class GeneralStore {
     // TODO: Set activeThread to null - this is for testing
     this.activeThread = null;
     this.threadFullscreen = false;
+  }
+
+  @action setOpenedDefaultThread() {
+    this.openedDefaultThread = true;
   }
 
   @action setFile(file: File) {

--- a/src/ui/Forum/index.tsx
+++ b/src/ui/Forum/index.tsx
@@ -44,7 +44,7 @@ export default observer(({ guild, channel }: Props) => {
     }, [error?.message])
 
     useEffect(() => {
-        if (queryParams.has('thread')) {
+        if (queryParams.has('thread') && !generalStore.openedDefaultThread) {
             const threads = data?.channel?.threads as Thread[]
             if (threads) {
                 const thread = threads.find(t => t.id === queryParams.get('thread'))
@@ -59,6 +59,7 @@ export default observer(({ guild, channel }: Props) => {
                         autoDismiss: 0,
                     })
                 }
+                generalStore.setOpenedDefaultThread()
             }
         }
     }, [data?.channel?.threads])

--- a/src/views/Messages/Header/ThreadBrowser/index.tsx
+++ b/src/views/Messages/Header/ThreadBrowser/index.tsx
@@ -65,7 +65,7 @@ export default observer(({ count }: { count: number }) => {
     }, [error?.message])
 
     useEffect(() => {
-        if (queryParams.has('thread')) {
+        if (queryParams.has('thread') && !generalStore.openedDefaultThread) {
             const threads = data?.channel?.threads as Threads_channel_threads_ThreadChannel[]
             if (threads) {
                 const thread = threads.find(t => t.id === queryParams.get('thread'))
@@ -80,6 +80,7 @@ export default observer(({ count }: { count: number }) => {
                         autoDismiss: 0,
                     })
                 }
+                generalStore.setOpenedDefaultThread()
             }
         }
     }, [data?.channel?.threads])


### PR DESCRIPTION
there's a bug in the current default thread implementation (for text channels and forums) where closing the default thread doesn't work, this saves state when the thread is opened so it doesn't keep re-opening the thread