### PR TITLE
preserve image query params (fix attachment auth)

### DIFF
--- a/src/ui/shared/ExpandableImage/optimize.ts
+++ b/src/ui/shared/ExpandableImage/optimize.ts
@@ -17,7 +17,7 @@ const optimize = ({ width, height, url }) => {
 
   if (match) {
     const [, id1, id2, file, type] = match
-    const params = new URLSearchParams()
+    const params = new URL(url).searchParams
 
     params.set('height', `${Math.round(height * devicePixelRatio)}`)
     params.set('width', `${Math.round(width * devicePixelRatio)}`)


### PR DESCRIPTION
currently we are dropping the params, which breaks Discord's new attachment auth system